### PR TITLE
Fixes for 2.15.0

### DIFF
--- a/src/GrasshopperTeklaDrawingLink/Components/Annotations/CreateArcComponent.cs
+++ b/src/GrasshopperTeklaDrawingLink/Components/Annotations/CreateArcComponent.cs
@@ -65,11 +65,11 @@ namespace GTDrawingLink.Components.Annotations
         private static Arc InsertArc(ViewBase view,
                                      Rhino.Geometry.Arc rhinoArc,
                                      Arc.ArcAttributes attributes)
-        {
+        {            
             var circle = new Arc(view,
-                                 rhinoArc.StartPoint.ToTekla(),
-                                 rhinoArc.MidPoint.ToTekla(),
                                  rhinoArc.EndPoint.ToTekla(),
+                                 rhinoArc.StartPoint.ToTekla(),
+                                 rhinoArc.Center.ToTekla(),
                                  attributes);
             circle.Insert();
 

--- a/src/GrasshopperTeklaDrawingLink/Tools/ReflectionHelper.cs
+++ b/src/GrasshopperTeklaDrawingLink/Tools/ReflectionHelper.cs
@@ -51,10 +51,13 @@ namespace GTDrawingLink.Tools
             var type = obj.GetType();
             foreach (var propertyInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
+                if (propertiesWithValues.ContainsKey(propertyInfo.Name))
+                    continue;
+                
                 propertiesWithValues.Add(propertyInfo.Name, propertyInfo.GetValue(obj).ToString());
             }
 
-            return string.Join("\n", propertiesWithValues.OrderBy(p=>p.Key).Select(p => $"{p.Key}: {p.Value}"));
+            return string.Join("\n", propertiesWithValues.OrderBy(p => p.Key).Select(p => $"{p.Key}: {p.Value}"));
         }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/TeklaLineSegmentGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TeklaLineSegmentGoo.cs
@@ -64,7 +64,14 @@ namespace GTDrawingLink.Types
 
         public override bool CastTo<Q>(ref Q target)
         {
-            if (target is IGH_GeometricGoo && Value != null)
+            if (target is GH_Curve)
+            {
+                var line = Value.ToRhino().ToNurbsCurve();
+
+                target = (Q)(object)new GH_Curve(line);
+                return true;
+            }
+            else if(target is IGH_GeometricGoo && Value != null)
             {
                 target = (Q)(object)new GH_Line(Value.ToRhino());
                 return true;


### PR DESCRIPTION
Fixed:
- proper order of arguments in the Insert Arc component
- modify view's restriction box works correctly for rotated views
- Line Segment is properly casted to GH_Curve