### PR TITLE
Serializable attributes

### DIFF
--- a/src/GrasshopperTeklaDrawingLink/Components/Attributes/ModelObjectHatchAttributesComponent.cs
+++ b/src/GrasshopperTeklaDrawingLink/Components/Attributes/ModelObjectHatchAttributesComponent.cs
@@ -23,7 +23,7 @@ namespace GTDrawingLink.Components.AttributesComponents
         protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
             pManager.AddTextParameter(_hatchNameParameter, "N", "Hatch name", GH_ParamAccess.item);
-            pManager.AddParameter(new EnumParam<DrawingHatchColors>(ParamInfos.DrawingHatchColor, GH_ParamAccess.item));
+            AddOptionalParameter(pManager, new EnumParam<DrawingHatchColors>(ParamInfos.DrawingHatchColor, GH_ParamAccess.item));
             AddOptionalParameter(pManager, new EnumParam<DrawingHatchColors>(ParamInfos.DrawingBackgroundHatchColor, GH_ParamAccess.item));
         }
 

--- a/src/GrasshopperTeklaDrawingLink/Types/ArcAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ArcAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class ArcAttributesGoo : TeklaAttributesBaseGoo<Arc.ArcAttributes>
     {
+        public ArcAttributesGoo() { }
+
+        public ArcAttributesGoo(Arc.ArcAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new ArcAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ArcAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ArcAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class ArcAttributesParam : GH_Param<GH_Goo<Arc.ArcAttributes>>
+    public class ArcAttributesParam : GH_PersistentParam<ArcAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public ArcAttributesParam(IGH_InstanceDescription tag)
+        public ArcAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public ArcAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public ArcAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Arc.ArcAttributes> InstantiateT()
+        protected override ArcAttributesGoo InstantiateT()
         {
             return new ArcAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref ArcAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<ArcAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ArrowAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ArrowAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class ArrowAttributesGoo : TeklaAttributesBaseGoo<ArrowheadAttributes>
     {
+        public ArrowAttributesGoo() { }
+
+        public ArrowAttributesGoo(ArrowheadAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new ArrowAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ArrowAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ArrowAttributesParam.cs
@@ -1,26 +1,31 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
-
 using GTDrawingLink.Tools;
-
 using System;
+using System.Collections.Generic;
 
-using Tekla.Structures.Drawing;
-
-namespace GTDrawingLink.Types {
-    public class ArrowAttributesParam : GH_Param<GH_Goo<ArrowheadAttributes>> {
+namespace GTDrawingLink.Types
+{
+    public class ArrowAttributesParam : GH_PersistentParam<ArrowAttributesGoo> {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public ArrowAttributesParam(IGH_InstanceDescription tag)
+        public ArrowAttributesParam(GH_InstanceDescription tag)
             : base(tag) {
         }
 
-        public ArrowAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access) {
+        public ArrowAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag) 
+        {
+            Access = access;
         }
 
-        protected override GH_Goo<ArrowheadAttributes> InstantiateT() {
+        protected override ArrowAttributesGoo InstantiateT() {
             return new ArrowAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref ArrowAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<ArrowAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/BoltAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/BoltAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class BoltAttributesGoo : TeklaAttributesBaseGoo<Bolt.BoltAttributes>
     {
+        public BoltAttributesGoo() { }
+
+        public BoltAttributesGoo(Bolt.BoltAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new BoltAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/BoltAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/BoltAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class BoltAttributesParam : GH_Param<GH_Goo<Bolt.BoltAttributes>>
+    public class BoltAttributesParam : GH_PersistentParam<BoltAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public BoltAttributesParam(IGH_InstanceDescription tag)
+        public BoltAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public BoltAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public BoltAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Bolt.BoltAttributes> InstantiateT()
+        protected override BoltAttributesGoo InstantiateT()
         {
             return new BoltAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref BoltAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<BoltAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/CircleAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/CircleAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class CircleAttributesGoo : TeklaAttributesBaseGoo<Circle.CircleAttributes>
     {
+        public CircleAttributesGoo() { }
+
+        public CircleAttributesGoo(Circle.CircleAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new CircleAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/CircleAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/CircleAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class CircleAttributesParam : GH_Param<GH_Goo<Circle.CircleAttributes>>
+    public class CircleAttributesParam : GH_PersistentParam<CircleAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public CircleAttributesParam(IGH_InstanceDescription tag)
+        public CircleAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public CircleAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public CircleAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Circle.CircleAttributes> InstantiateT()
+        protected override CircleAttributesGoo InstantiateT()
         {
             return new CircleAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref CircleAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<CircleAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/EmbeddedObjectAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/EmbeddedObjectAttributesGoo.cs
@@ -1,9 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class EmbeddedObjectAttributesGoo : TeklaAttributesBaseGoo<EmbeddedObjectAttributes>
     {
+        public EmbeddedObjectAttributesGoo() { }
 
+        public EmbeddedObjectAttributesGoo(EmbeddedObjectAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new EmbeddedObjectAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/EmbeddedObjectAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/EmbeddedObjectAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class EmbeddedObjectAttributesParam : GH_Param<GH_Goo<EmbeddedObjectAttributes>>
+    public class EmbeddedObjectAttributesParam : GH_PersistentParam<EmbeddedObjectAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public EmbeddedObjectAttributesParam(IGH_InstanceDescription tag)
+        public EmbeddedObjectAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public EmbeddedObjectAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public EmbeddedObjectAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<EmbeddedObjectAttributes> InstantiateT()
+        protected override EmbeddedObjectAttributesGoo InstantiateT()
         {
             return new EmbeddedObjectAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref EmbeddedObjectAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<EmbeddedObjectAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/FontAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/FontAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class FontAttributesGoo : TeklaAttributesBaseGoo<FontAttributes>
     {
+        public FontAttributesGoo() { }
+
+        public FontAttributesGoo(FontAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new FontAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/FontAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/FontAttributesParam.cs
@@ -1,26 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
-
 using GTDrawingLink.Tools;
-
 using System;
+using System.Collections.Generic;
 
-using Tekla.Structures.Drawing;
-
-namespace GTDrawingLink.Types {
-    public class FontAttributesParam : GH_Param<GH_Goo<FontAttributes>> {
+namespace GTDrawingLink.Types
+{
+    public class FontAttributesParam : GH_PersistentParam<FontAttributesGoo>
+    {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public FontAttributesParam(IGH_InstanceDescription tag)
-            : base(tag) {
+        public FontAttributesParam(GH_InstanceDescription tag)
+            : base(tag)
+        {
         }
 
-        public FontAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access) {
+        public FontAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
+        {
+            Access = access;
         }
 
-        protected override GH_Goo<FontAttributes> InstantiateT() {
+        protected override FontAttributesGoo InstantiateT()
+        {
             return new FontAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref FontAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<FontAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/FrameAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/FrameAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class FrameAttributesGoo : TeklaAttributesBaseGoo<Frame>
     {
+        public FrameAttributesGoo() { }
+
+        public FrameAttributesGoo(Frame attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new FrameAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/FrameAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/FrameAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class FrameAttributesParam : GH_Param<GH_Goo<Frame>>
+    public class FrameAttributesParam : GH_PersistentParam<FrameAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public FrameAttributesParam(IGH_InstanceDescription tag)
+        public FrameAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public FrameAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public FrameAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Frame> InstantiateT()
+        protected override FrameAttributesGoo InstantiateT()
         {
             return new FrameAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref FrameAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<FrameAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/LineAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/LineAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class LineAttributesGoo : TeklaAttributesBaseGoo<Line.LineAttributes>
     {
+        public LineAttributesGoo() { }
+
+        public LineAttributesGoo(Line.LineAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new LineAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/LineAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/LineAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class LineAttributesParam : GH_Param<GH_Goo<Line.LineAttributes>>
+    public class LineAttributesParam : GH_PersistentParam<LineAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public LineAttributesParam(IGH_InstanceDescription tag)
+        public LineAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public LineAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public LineAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Line.LineAttributes> InstantiateT()
+        protected override LineAttributesGoo InstantiateT()
         {
             return new LineAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref LineAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<LineAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/LineTypeAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/LineTypeAttributesGoo.cs
@@ -1,17 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class LineTypeAttributesGoo : TeklaAttributesBaseGoo<LineTypeAttributes>
     {
-        public LineTypeAttributesGoo() : base()
-        {
+        public LineTypeAttributesGoo() { }
 
+        public LineTypeAttributesGoo(LineTypeAttributes attributes)
+        {
+            Value = attributes;
         }
-
-        public LineTypeAttributesGoo(LineTypeAttributes attributes) : base(attributes)
+        public override IGH_Goo Duplicate()
         {
-
+            return new LineTypeAttributesGoo(Value);
         }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/LineTypeAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/LineTypeAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-	public class LineTypeAttributesParam : GH_Param<GH_Goo<LineTypeAttributes>>
-	{
-		public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
+    public class LineTypeAttributesParam : GH_PersistentParam<LineTypeAttributesGoo>
+    {
+        public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-		public LineTypeAttributesParam(IGH_InstanceDescription tag)
-			: base(tag)
-		{
-		}
+        public LineTypeAttributesParam(GH_InstanceDescription tag)
+            : base(tag)
+        {
+        }
 
-		public LineTypeAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-			: base(tag, access)
-		{
-		}
+        public LineTypeAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
+        {
+            Access = access;
+        }
 
-		protected override GH_Goo<LineTypeAttributes> InstantiateT()
-		{
-			return new LineTypeAttributesGoo();
-		}
-	}
+        protected override LineTypeAttributesGoo InstantiateT()
+        {
+            return new LineTypeAttributesGoo();
+        }
+
+        protected override GH_GetterResult Prompt_Singular(ref LineTypeAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<LineTypeAttributesGoo> values)
+            => GH_GetterResult.cancel;
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ModelObjectHatchAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ModelObjectHatchAttributesGoo.cs
@@ -1,11 +1,12 @@
 ﻿using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
+using System.Reflection;
 using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
-    public class ModelObjectHatchAttributesGoo : GH_Goo<ModelObjectHatchAttributes>
+    public class ModelObjectHatchAttributesGoo : TeklaAttributesBaseGoo<ModelObjectHatchAttributes>
     {
         public override bool IsValid => true;
 
@@ -21,9 +22,27 @@ namespace GTDrawingLink.Types
             : base(attr)
         {
         }
+
         public override IGH_Goo Duplicate()
         {
-            throw new NotImplementedException();
+            if (Value == null)
+                throw new NotImplementedException();
+
+            var type = typeof(ModelObjectHatchAttributes);
+            var duplicate = (ModelObjectHatchAttributes)type.GetConstructor(
+                  BindingFlags.NonPublic | BindingFlags.Instance,
+                  null, Type.EmptyTypes, null).Invoke(null);
+
+            foreach (var hatchProperty in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!hatchProperty.CanRead || !hatchProperty.CanWrite)
+                    continue;
+
+                var existingValue = hatchProperty.GetValue(Value);
+                hatchProperty.SetValue(duplicate, existingValue);
+            }
+
+            return new ModelObjectHatchAttributesGoo(duplicate);
         }
 
         public override bool CastFrom(object source)

--- a/src/GrasshopperTeklaDrawingLink/Types/ModelObjectHatchAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ModelObjectHatchAttributesParam.cs
@@ -10,23 +10,30 @@ using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
-	public class ModelObjectHatchAttributesParam : GH_Param<GH_Goo<ModelObjectHatchAttributes>>
+	public class ModelObjectHatchAttributesParam : GH_PersistentParam<ModelObjectHatchAttributesGoo>
 	{
 		public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-		public ModelObjectHatchAttributesParam(IGH_InstanceDescription tag)
+		public ModelObjectHatchAttributesParam(GH_InstanceDescription tag)
 			: base(tag)
 		{
 		}
 
-		public ModelObjectHatchAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-			: base(tag, access)
+		public ModelObjectHatchAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+			: base(tag)
 		{
+			Access = access;
 		}
 
-		protected override GH_Goo<ModelObjectHatchAttributes> InstantiateT()
+		protected override ModelObjectHatchAttributesGoo InstantiateT()
 		{
 			return new ModelObjectHatchAttributesGoo();
-		}
-	}
+        }
+
+        protected override GH_GetterResult Prompt_Singular(ref ModelObjectHatchAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<ModelObjectHatchAttributesGoo> values)
+            => GH_GetterResult.cancel;
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PartAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PartAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class PartAttributesGoo : TeklaAttributesBaseGoo<Part.PartAttributes>
     {
+        public PartAttributesGoo() { }
+
+        public PartAttributesGoo(Part.PartAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new PartAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PartAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PartAttributesParam.cs
@@ -2,27 +2,35 @@
 using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
+using System.Collections.Generic;
 using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
-    public class PartAttributesParam : GH_Param<GH_Goo<Part.PartAttributes>>
+    public class PartAttributesParam : GH_PersistentParam<PartAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public PartAttributesParam(IGH_InstanceDescription tag)
+        public PartAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public PartAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public PartAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Part.PartAttributes> InstantiateT()
+        protected override PartAttributesGoo InstantiateT()
         {
             return new PartAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref PartAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<PartAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PlacingBaseGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PlacingBaseGoo.cs
@@ -1,4 +1,5 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
@@ -11,6 +12,11 @@ namespace GTDrawingLink.Types
         public PlacingBaseGoo(PlacingBase placingBase)
         {
             Value = placingBase;
+        }
+
+        public override IGH_Goo Duplicate()
+        {
+            return new PlacingBaseGoo(Value);
         }
 
         public override string ToString()

--- a/src/GrasshopperTeklaDrawingLink/Types/PlacingBaseParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PlacingBaseParam.cs
@@ -1,31 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
-
 using GTDrawingLink.Tools;
-
 using System;
-
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class PlacingBaseParam : GH_Param<GH_Goo<PlacingBase>>
+    public class PlacingBaseParam : GH_PersistentParam<PlacingBaseGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public PlacingBaseParam(IGH_InstanceDescription tag)
+        public PlacingBaseParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public PlacingBaseParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public PlacingBaseParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<PlacingBase> InstantiateT()
+        protected override PlacingBaseGoo InstantiateT()
         {
             return new PlacingBaseGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref PlacingBaseGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<PlacingBaseGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PolygonAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PolygonAttributesGoo.cs
@@ -1,6 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
-    public class PolygonAttributesGoo : TeklaAttributesBaseGoo<Polygon.PolygonAttributes> { }
+    public class PolygonAttributesGoo : TeklaAttributesBaseGoo<Polygon.PolygonAttributes>
+    {
+        public PolygonAttributesGoo() { }
+
+        public PolygonAttributesGoo(Polygon.PolygonAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new PolygonAttributesGoo(Value);
+        }
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PolygonAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PolygonAttributesParam.cs
@@ -1,30 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class PolygonAttributesParam : GH_Param<GH_Goo<Polygon.PolygonAttributes>>
+    public class PolygonAttributesParam : GH_PersistentParam<PolygonAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public PolygonAttributesParam(IGH_InstanceDescription tag)
+        public PolygonAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public PolygonAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public PolygonAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Polygon.PolygonAttributes> InstantiateT()
+        protected override PolygonAttributesGoo InstantiateT()
         {
             return new PolygonAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref PolygonAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<PolygonAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
-
-
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PolylineAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PolylineAttributesGoo.cs
@@ -1,6 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
-    public class PolylineAttributesGoo : TeklaAttributesBaseGoo<Polyline.PolylineAttributes> { }
+    public class PolylineAttributesGoo : TeklaAttributesBaseGoo<Polyline.PolylineAttributes>
+    {
+        public PolylineAttributesGoo() { }
+
+        public PolylineAttributesGoo(Polyline.PolylineAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new PolylineAttributesGoo(Value);
+        }
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/PolylineAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/PolylineAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class PolylineAttributesParam : GH_Param<GH_Goo<Polyline.PolylineAttributes>>
+    public class PolylineAttributesParam : GH_PersistentParam<PolylineAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public PolylineAttributesParam(IGH_InstanceDescription tag)
+        public PolylineAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public PolylineAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public PolylineAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Polyline.PolylineAttributes> InstantiateT()
+        protected override PolylineAttributesGoo InstantiateT()
         {
             return new PolylineAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref PolylineAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<PolylineAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ReinforcementAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ReinforcementAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class ReinforcementAttributesGoo : TeklaAttributesBaseGoo<ReinforcementBase.ReinforcementSingleAttributes>
     {
+        public ReinforcementAttributesGoo() { }
+
+        public ReinforcementAttributesGoo(ReinforcementBase.ReinforcementSingleAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new ReinforcementAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ReinforcementAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ReinforcementAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class ReinforcementAttributesParam : GH_Param<GH_Goo<ReinforcementBase.ReinforcementSingleAttributes>>
+    public class ReinforcementAttributesParam : GH_PersistentParam<ReinforcementAttributesGoo>
 	{
 		public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-		public ReinforcementAttributesParam(IGH_InstanceDescription tag)
+		public ReinforcementAttributesParam(GH_InstanceDescription tag)
 			: base(tag)
 		{
 		}
 
-		public ReinforcementAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-			: base(tag, access)
+		public ReinforcementAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+			: base(tag)
 		{
+			Access = access;
 		}
 
-		protected override GH_Goo<ReinforcementBase.ReinforcementSingleAttributes> InstantiateT()
+		protected override ReinforcementAttributesGoo InstantiateT()
 		{
 			return new ReinforcementAttributesGoo();
-		}
-	}
+        }
+
+        protected override GH_GetterResult Prompt_Singular(ref ReinforcementAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<ReinforcementAttributesGoo> values)
+            => GH_GetterResult.cancel;
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ReinforcementMeshAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ReinforcementMeshAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class ReinforcementMeshAttributesGoo : TeklaAttributesBaseGoo<ReinforcementBase.ReinforcementMeshAttributes>
     {
+        public ReinforcementMeshAttributesGoo() { }
+
+        public ReinforcementMeshAttributesGoo(ReinforcementBase.ReinforcementMeshAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new ReinforcementMeshAttributesGoo(Value);
+        }
     } 
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/ReinforcementMeshAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/ReinforcementMeshAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class ReinforcementMeshAttributesParam : GH_Param<GH_Goo<ReinforcementBase.ReinforcementMeshAttributes>>
-	{
-		public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
+    public class ReinforcementMeshAttributesParam : GH_PersistentParam<ReinforcementMeshAttributesGoo>
+    {
+        public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-		public ReinforcementMeshAttributesParam(IGH_InstanceDescription tag)
-			: base(tag)
-		{
-		}
+        public ReinforcementMeshAttributesParam(GH_InstanceDescription tag)
+            : base(tag)
+        {
+        }
 
-		public ReinforcementMeshAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-			: base(tag, access)
-		{
-		}
+        public ReinforcementMeshAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
+        {
+            Access = access;
+        }
 
-		protected override GH_Goo<ReinforcementBase.ReinforcementMeshAttributes> InstantiateT()
-		{
-			return new ReinforcementMeshAttributesGoo();
-		}
-	}
+        protected override ReinforcementMeshAttributesGoo InstantiateT()
+        {
+            return new ReinforcementMeshAttributesGoo();
+        }
+
+        protected override GH_GetterResult Prompt_Singular(ref ReinforcementMeshAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<ReinforcementMeshAttributesGoo> values)
+            => GH_GetterResult.cancel;
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/SymbolAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/SymbolAttributesGoo.cs
@@ -1,9 +1,21 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class SymbolAttributesGoo : TeklaAttributesBaseGoo<SymbolAttributes>
     {
+        public SymbolAttributesGoo() { }
+
+        public SymbolAttributesGoo(SymbolAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new SymbolAttributesGoo(Value);
+        }
+
         public override bool CastFrom(object source)
         {
             if (source is SymbolAttributes)

--- a/src/GrasshopperTeklaDrawingLink/Types/SymbolAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/SymbolAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class SymbolAttributesParam : GH_Param<GH_Goo<SymbolAttributes>>
+    public class SymbolAttributesParam : GH_PersistentParam<SymbolAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public SymbolAttributesParam(IGH_InstanceDescription tag)
+        public SymbolAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public SymbolAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public SymbolAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<SymbolAttributes> InstantiateT()
+        protected override SymbolAttributesGoo InstantiateT()
         {
             return new SymbolAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref SymbolAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<SymbolAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/SymbolInfoGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/SymbolInfoGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class SymbolInfoGoo : TeklaAttributesBaseGoo<SymbolInfo>
     {
+        public SymbolInfoGoo() { }
+
+        public SymbolInfoGoo(SymbolInfo attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new SymbolInfoGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/SymbolInfoParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/SymbolInfoParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class SymbolInfoParam : GH_Param<GH_Goo<SymbolInfo>>
+    public class SymbolInfoParam : GH_PersistentParam<SymbolInfoGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public SymbolInfoParam(IGH_InstanceDescription tag)
+        public SymbolInfoParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public SymbolInfoParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public SymbolInfoParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<SymbolInfo> InstantiateT()
+        protected override SymbolInfoGoo InstantiateT()
         {
             return new SymbolInfoGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref SymbolInfoGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<SymbolInfoGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/TeklaAttributesBaseGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TeklaAttributesBaseGoo.cs
@@ -2,7 +2,6 @@
 using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/GrasshopperTeklaDrawingLink/Types/TeklaAttributesBaseGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TeklaAttributesBaseGoo.cs
@@ -110,7 +110,7 @@ namespace GTDrawingLink.Types
         public override bool Read(GH_IReader reader)
         {
             var neededType = typeof(T);
-            Value = (T)Activator.CreateInstance(neededType);
+            Value = (T)Activator.CreateInstance(neededType, nonPublic: true);
 
             if (reader.ItemCount > 1) // there is always one property set by GH, TypeName
                 FillProperties(Value, reader);

--- a/src/GrasshopperTeklaDrawingLink/Types/TextAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextAttributesGoo.cs
@@ -1,4 +1,7 @@
-﻿using Tekla.Structures.Drawing;
+﻿using GH_IO.Serialization;
+using Grasshopper.Kernel.Types;
+using System;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
@@ -9,6 +12,10 @@ namespace GTDrawingLink.Types
         public TextAttributesGoo(Text.TextAttributes attributes)
         {
             Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new TextAttributesGoo(Value);
         }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/TextAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextAttributesGoo.cs
@@ -1,6 +1,4 @@
-﻿using GH_IO.Serialization;
-using Grasshopper.Kernel.Types;
-using System;
+﻿using Grasshopper.Kernel.Types;
 using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types

--- a/src/GrasshopperTeklaDrawingLink/Types/TextAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextAttributesParam.cs
@@ -1,26 +1,35 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 
 using GTDrawingLink.Tools;
 
 using System;
+using System.Collections.Generic;
 
-using Tekla.Structures.Drawing;
-
-namespace GTDrawingLink.Types {
-    public class TextAttributesParam : GH_Param<GH_Goo<Text.TextAttributes>> {
+namespace GTDrawingLink.Types
+{
+    public class TextAttributesParam : GH_PersistentParam<TextAttributesGoo>
+    {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public TextAttributesParam(IGH_InstanceDescription tag)
-            : base(tag) {
+        public TextAttributesParam(GH_InstanceDescription tag)
+            : base(tag)
+        {
         }
 
-        public TextAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access) {
+        public TextAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access) : base(tag)
+        {
+            Access = access;
         }
 
-        protected override GH_Goo<Text.TextAttributes> InstantiateT() {
+        protected override TextAttributesGoo InstantiateT()
+        {
             return new TextAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref TextAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<TextAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/TextAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextAttributesParam.cs
@@ -1,7 +1,5 @@
 ﻿using Grasshopper.Kernel;
-
 using GTDrawingLink.Tools;
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GrasshopperTeklaDrawingLink/Types/TextFileAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextFileAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class TextFileAttributesGoo : TeklaAttributesBaseGoo<TextFile.TextFileAttributes>
     {
+        public TextFileAttributesGoo() { }
+
+        public TextFileAttributesGoo(TextFile.TextFileAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new TextFileAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/TextFileAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/TextFileAttributesParam.cs
@@ -1,30 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class TextFileAttributesParam : GH_Param<GH_Goo<TextFile.TextFileAttributes>>
+    public class TextFileAttributesParam : GH_PersistentParam<TextFileAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public TextFileAttributesParam(IGH_InstanceDescription tag)
+        public TextFileAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public TextFileAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public TextFileAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<TextFile.TextFileAttributes> InstantiateT()
+        protected override TextFileAttributesGoo InstantiateT()
         {
             return new TextFileAttributesGoo();
         }
-    }
 
-    
+        protected override GH_GetterResult Prompt_Singular(ref TextFileAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<TextFileAttributesGoo> values)
+            => GH_GetterResult.cancel;
+    }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/WeldAttributesGoo.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/WeldAttributesGoo.cs
@@ -1,8 +1,19 @@
-﻿using Tekla.Structures.Drawing;
+﻿using Grasshopper.Kernel.Types;
+using Tekla.Structures.Drawing;
 
 namespace GTDrawingLink.Types
 {
     public class WeldAttributesGoo : TeklaAttributesBaseGoo<Weld.WeldAttributes>
     {
+        public WeldAttributesGoo() { }
+
+        public WeldAttributesGoo(Weld.WeldAttributes attributes)
+        {
+            Value = attributes;
+        }
+        public override IGH_Goo Duplicate()
+        {
+            return new WeldAttributesGoo(Value);
+        }
     }
 }

--- a/src/GrasshopperTeklaDrawingLink/Types/WeldAttributesParam.cs
+++ b/src/GrasshopperTeklaDrawingLink/Types/WeldAttributesParam.cs
@@ -1,28 +1,34 @@
 ﻿using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GTDrawingLink.Tools;
 using System;
-using Tekla.Structures.Drawing;
+using System.Collections.Generic;
 
 namespace GTDrawingLink.Types
 {
-    public class WeldAttributesParam : GH_Param<GH_Goo<Weld.WeldAttributes>>
+    public class WeldAttributesParam : GH_PersistentParam<WeldAttributesGoo>
     {
         public override Guid ComponentGuid => VersionSpecificConstants.GetGuid(GetType());
 
-        public WeldAttributesParam(IGH_InstanceDescription tag)
+        public WeldAttributesParam(GH_InstanceDescription tag)
             : base(tag)
         {
         }
 
-        public WeldAttributesParam(IGH_InstanceDescription tag, GH_ParamAccess access)
-            : base(tag, access)
+        public WeldAttributesParam(GH_InstanceDescription tag, GH_ParamAccess access)
+            : base(tag)
         {
+            Access = access;
         }
 
-        protected override GH_Goo<Weld.WeldAttributes> InstantiateT()
+        protected override WeldAttributesGoo InstantiateT()
         {
             return new WeldAttributesGoo();
         }
+
+        protected override GH_GetterResult Prompt_Singular(ref WeldAttributesGoo value)
+            => GH_GetterResult.cancel;
+
+        protected override GH_GetterResult Prompt_Plural(ref List<WeldAttributesGoo> values)
+            => GH_GetterResult.cancel;
     }
 }


### PR DESCRIPTION
Attributes can be serialized (internalize data in GH).
Applied to:

- ArcAttributes
- ArrowheadAttributes
- BoltAttributes
- CircleAttributes
- EmbeddedObjectAttributes
- FontAttributes
- Frame
- LineAttributes
- LineTypeAttributes
- ModelObjectHatchAttributes
- PartAttributes
- PlacingAttributes
- PolygonAttributes
- PolylineAttributes
- ReinforcementSingleAttributes
- ReinforcementMeshAttributes
- SymbolAttributes
- SymbolInfo
- TextAttributes
- TextFileAttributes
- WeldAttributes