### PR TITLE
Grasshopper Application working like a macro

### DIFF
--- a/samples/Macro-script/Grasshopper - Macro sample.cs
+++ b/samples/Macro-script/Grasshopper - Macro sample.cs
@@ -1,0 +1,45 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+using Tekla.Structures;
+using TSM = Tekla.Structures.Model;
+using Tekla.Structures.Model;
+
+namespace Tekla.Technology.Akit.UserScript
+{
+    public class Script
+    {
+        public static void Run(Tekla.Technology.Akit.IScript akit)
+        {
+            string TSBinaryDir = "";
+            TSM.Model CurrentModel = new TSM.Model();
+            TeklaStructuresSettings.GetAdvancedOption("XSDATADIR", ref TSBinaryDir);
+			
+            string ApplicationName = "Grasshopper Application.exe";
+            string ApplicationPath = Path.Combine(TSBinaryDir, "Environments\\common\\extensions\\GrasshopperApplication\\" + ApplicationName);
+
+            Process NewProcess = new Process();
+
+            if (File.Exists(ApplicationPath))
+            {
+                NewProcess.StartInfo.FileName = ApplicationPath;
+
+                NewProcess.StartInfo.Arguments = "-f \"SETTINGS.DrawingLink.UI.MainWindow.xml\"";
+
+                try
+                {
+                    NewProcess.Start();
+                    NewProcess.WaitForExit();
+                }
+                catch
+                {
+                    MessageBox.Show(ApplicationName + " failed to start.");
+                }
+            }
+            else
+            {
+                MessageBox.Show(ApplicationName + " not found.");
+            }
+        }
+    }
+}

--- a/samples/Macro-script/Instruction.md
+++ b/samples/Macro-script/Instruction.md
@@ -1,0 +1,17 @@
+# Script Like a Macro
+
+*Script like a macro* is a feature of the **Grasshopper Application** that lets you quickly run your Grasshopper scripts without manually reloading settings in the Grasshopper Application window.
+
+## How It Works
+
+This feature relies on an already-opened instance of the Grasshopper Application. Open it once, minimize it or move it to an unused corner of your screen, then trigger the macro. The macro will instruct the open instance to do its job.
+
+## Configuration
+
+A sample macro is provided in the `Grasshopper - Macro sample.cs` file. You'll need to adapt its content to your needs (it's a plain text file, so Notepad is sufficient). Look for this line:
+
+​```
+NewProcess.StartInfo.Arguments = "-f \"SETTINGS.DrawingLink.UI.MainWindow.xml\"";
+​```
+
+This is the anchor point between your macro and the Grasshopper Application. Change it to reference the pre-saved settings of the Grasshopper Application (visible as a combobox at the top of the UI), which control both the script path and the input values.

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
   <PropertyGroup>
-    <TeklaVersion Condition="'$(Configuration)' == 'Debug'">2024.0</TeklaVersion>
+    <TeklaVersion Condition="'$(Configuration)' == 'Debug'">2025.0</TeklaVersion>
   </PropertyGroup>
 </Project>

--- a/src/DrawingLink.UI/App.xaml
+++ b/src/DrawingLink.UI/App.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:DrawingLink.UI"
-             Startup="Application_Startup">
+             Startup="Application_Startup"
+             Exit="Application_Exit">
   <Application.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -64,6 +64,7 @@ namespace DrawingLink.UI
                 }
 
                 RunScript(startupOptions.SettingsFilePath);
+                Shutdown();
             }
         }
 

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -28,13 +28,21 @@ namespace DrawingLink.UI
             var mainWindowViewModel = new MainWindowViewModel();
             var mainWindow = new MainWindow(mainWindowViewModel, rhinoVersions);
             new System.Windows.Interop.WindowInteropHelper(mainWindow).Owner = Tekla.Structures.Dialog.MainWindow.Frame.Handle;
-            mainWindow.Show();
-
-            if (startupOptions.SettingsFilePath != null)
+            
+            if (string.IsNullOrWhiteSpace(startupOptions.SettingsFilePath))
             {
+                mainWindow.Show();
+            }
+            else
+            {
+                mainWindow.InitalizeRhino();
                 mainWindow.LoadValues(startupOptions.SettingsFilePath);
                 mainWindow.ExecuteScript();
-                mainWindow.Close();
+
+                Application.Current.Dispatcher.InvokeAsync(() =>
+                {
+                    Application.Current.Shutdown(0);
+                });
             }
         }
 

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -131,7 +131,7 @@ namespace DrawingLink.UI
 
         private void Log(string message)
         {
-            File.AppendAllText(@"C:\temp\PseudoLog.txt", $"{DateTime.Now}: {message}\n");
+            //File.AppendAllText(@"C:\temp\PseudoLog.txt", $"{DateTime.Now}: {message}\n");
         }
 
         private void HandleTrigger(string message)

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -1,8 +1,13 @@
-﻿using System;
+﻿using DrawingLink.UI.StartupUtils;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace DrawingLink.UI
@@ -18,32 +23,118 @@ namespace DrawingLink.UI
             @"C:\Program Files\Rhino 7\Plug-ins\Grasshopper"
         };
 
+        private CancellationTokenSource? _cts;
+        private MainWindow _mainWindow;
+
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-            var startupOptions = StartupOptions.ParseArguments(e.Args);
-
             var rhinoVersions = SetupRhinoFolders();
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
+            var teklaVersion = Tekla.Structures.TeklaStructuresInfo.GetCurrentProgramVersion();
+            var startupController = new StartupController(e, teklaVersion);
+            var operationMode = startupController.EstablishOperationMode();
+
+            Log(operationMode.ToString());
+
             var mainWindowViewModel = new MainWindowViewModel();
-            var mainWindow = new MainWindow(mainWindowViewModel, rhinoVersions);
-            new System.Windows.Interop.WindowInteropHelper(mainWindow).Owner = Tekla.Structures.Dialog.MainWindow.Frame.Handle;
-            
-            if (string.IsNullOrWhiteSpace(startupOptions.SettingsFilePath))
+            _mainWindow = new MainWindow(mainWindowViewModel, rhinoVersions);
+            new System.Windows.Interop.WindowInteropHelper(_mainWindow).Owner = Tekla.Structures.Dialog.MainWindow.Frame.Handle;
+
+            var startupOptions = StartupOptions.ParseArguments(e.Args);
+            if (operationMode.HasFlag(AppOperationMode.UI))
             {
-                mainWindow.Show();
+                if (operationMode.HasFlag(AppOperationMode.Server))
+                {
+                    _cts = new CancellationTokenSource();
+                    StartPipeServer(NamedPipeController.GetPipeName(teklaVersion), _cts.Token);
+                }
+
+                _mainWindow.Show();
             }
             else
             {
-                mainWindow.InitalizeRhino();
-                mainWindow.LoadValues(startupOptions.SettingsFilePath);
-                mainWindow.ExecuteScript();
-
-                Application.Current.Dispatcher.InvokeAsync(() =>
+                if (operationMode.HasFlag(AppOperationMode.Client))
                 {
-                    Application.Current.Shutdown(0);
-                });
+                    if (TrySignalExistingInstance(StartupOptionsDto.FromDomain(startupOptions), teklaVersion))
+                    {
+                        Shutdown();
+                        return;
+                    }
+                }
+
+                RunScript(startupOptions.SettingsFilePath);
             }
+        }
+
+        private void Application_Exit(object sender, ExitEventArgs e)
+        {
+            _cts?.Cancel();
+        }
+
+        private void RunScript(string settingsFilePath)
+        {
+            _mainWindow.InitalizeRhino();
+            _mainWindow.LoadValues(settingsFilePath);
+            _mainWindow.ExecuteScript();
+        }
+
+        private static bool TrySignalExistingInstance(StartupOptionsDto startupOptions, string teklaVersion)
+        {
+            try
+            {
+                using var client = new NamedPipeClientStream(".",
+                    NamedPipeController.GetPipeName(teklaVersion), PipeDirection.Out);
+
+                client.Connect(timeout: 2000);
+
+                using var writer = new StreamWriter(client) { AutoFlush = true };
+                writer.Write(JsonConvert.SerializeObject(startupOptions));
+                return true;
+            }
+            catch (TimeoutException)
+            {
+                return false; // No existing instance, this one should become the server
+            }
+        }
+        public void StartPipeServer(string pipeName, CancellationToken ct)
+        {
+            Task.Run(async () =>
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    using var server = new NamedPipeServerStream(
+                        pipeName,
+                        PipeDirection.In,
+                        NamedPipeServerStream.MaxAllowedServerInstances,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous);
+
+                    Log($"Pipe server initialized: {pipeName}");
+                    await server.WaitForConnectionAsync(ct);
+
+                    using var reader = new StreamReader(server);
+                    string? message = await reader.ReadToEndAsync();
+
+                    if (!string.IsNullOrEmpty(message))
+                        System.Windows.Application.Current.Dispatcher.Invoke(() => HandleTrigger(message));
+                }
+            }, ct);
+        }
+
+        private void Log(string message)
+        {
+            File.AppendAllText(@"C:\temp\PseudoLog.txt", $"{DateTime.Now}: {message}\n");
+        }
+
+        private void HandleTrigger(string message)
+        {
+            Log("Received message: " + message);
+
+            var startupOptions = JsonConvert.DeserializeObject<StartupOptionsDto>(message);
+            RunScript(startupOptions.SettingsFilePath);
+
+            Log("Handled message: " + message);
         }
 
         private List<Rhino.RhinoInfo> SetupRhinoFolders()

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -20,6 +20,8 @@ namespace DrawingLink.UI
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
+            var startupOptions = StartupOptions.ParseArguments(e.Args);
+
             var rhinoVersions = SetupRhinoFolders();
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
@@ -27,6 +29,13 @@ namespace DrawingLink.UI
             var mainWindow = new MainWindow(mainWindowViewModel, rhinoVersions);
             new System.Windows.Interop.WindowInteropHelper(mainWindow).Owner = Tekla.Structures.Dialog.MainWindow.Frame.Handle;
             mainWindow.Show();
+
+            if (startupOptions.SettingsFilePath != null)
+            {
+                mainWindow.LoadValues(startupOptions.SettingsFilePath);
+                mainWindow.ExecuteScript();
+                mainWindow.Close();
+            }
         }
 
         private List<Rhino.RhinoInfo> SetupRhinoFolders()

--- a/src/DrawingLink.UI/App.xaml.cs
+++ b/src/DrawingLink.UI/App.xaml.cs
@@ -98,6 +98,7 @@ namespace DrawingLink.UI
                 return false; // No existing instance, this one should become the server
             }
         }
+
         public void StartPipeServer(string pipeName, CancellationToken ct)
         {
             Task.Run(async () =>
@@ -118,7 +119,12 @@ namespace DrawingLink.UI
                     string? message = await reader.ReadToEndAsync();
 
                     if (!string.IsNullOrEmpty(message))
-                        System.Windows.Application.Current.Dispatcher.Invoke(() => HandleTrigger(message));
+                    {
+                        System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                        {
+                            HandleTrigger(message);
+                        });
+                    }
                 }
             }, ct);
         }
@@ -133,6 +139,9 @@ namespace DrawingLink.UI
             Log("Received message: " + message);
 
             var startupOptions = JsonConvert.DeserializeObject<StartupOptionsDto>(message);
+
+            _mainWindow.DisplayServerInfo(startupOptions.SettingsFilePath);
+
             RunScript(startupOptions.SettingsFilePath);
 
             Log("Handled message: " + message);

--- a/src/DrawingLink.UI/Installer/Manifest.xml
+++ b/src/DrawingLink.UI/Installer/Manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TEP Version="2.0">
 
-    <Product Id="GrasshopperApplication" UpgradeCode="59D4F7C4-C2D9-42A5-A3CC-079963B4DB6C" Version="1.6" Language="1033" 
+    <Product Id="GrasshopperApplication" UpgradeCode="59D4F7C4-C2D9-42A5-A3CC-079963B4DB6C" Version="1.7" Language="1033" 
         Name="Grasshopper Application" Manufacturer="Constructive Greg"  
         Description= "Part of the Grasshopper Drawing Link development project. Enables to utilize Rhino.Inside technology in Tekla Structures."
         IconPath="%TEPDEFINITIONFILEFOLDER%\..\icon.png" Type="Extension">

--- a/src/DrawingLink.UI/MainWindow.xaml
+++ b/src/DrawingLink.UI/MainWindow.xaml
@@ -76,6 +76,12 @@
       <local:ParameterViewer x:Name="parameterViewer" />
     </ScrollViewer>
 
+    <Label Grid.Row="2"
+           HorizontalAlignment="Right"
+           VerticalAlignment="Bottom"
+           FontStyle="Italic"
+           x:Name="serverModeInfo" />
+
     <Grid Grid.Row="2"
           x:Name="gridLoading">
       <Grid.RowDefinitions>
@@ -99,7 +105,7 @@
     <UIControls:WpfCreateApplyCancel x:Name="teklaBottomBar"
                                      Grid.Row="3"
                                      CreateClicked="WpfOkCreateCancel_CreateClicked"
-                                     ApplyClicked="WpfOkCreateCancel_ApplyClicked" 
-                                     CancelClicked="WpfOkCreateCancel_CancelClicked"/>
+                                     ApplyClicked="WpfOkCreateCancel_ApplyClicked"
+                                     CancelClicked="WpfOkCreateCancel_CancelClicked" />
   </Grid>
 </tsd:ApplicationWindowBase>

--- a/src/DrawingLink.UI/MainWindow.xaml.cs
+++ b/src/DrawingLink.UI/MainWindow.xaml.cs
@@ -254,7 +254,7 @@ namespace DrawingLink.UI
 
         private void ApplicationWindowBase_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            _instance.Dispose();
+            _instance?.Dispose();
         }
 
         private void WpfSaveLoad_AttributesLoaded(object sender, EventArgs e)

--- a/src/DrawingLink.UI/MainWindow.xaml.cs
+++ b/src/DrawingLink.UI/MainWindow.xaml.cs
@@ -244,6 +244,7 @@ namespace DrawingLink.UI
                 return;
             }
 
+            DisplayServerInfo(string.Empty);
             _instance.OpenGrasshopperDefinition(path);
         }
 
@@ -261,6 +262,8 @@ namespace DrawingLink.UI
         {
             if (!_loaded)
                 return;
+
+            DisplayServerInfo(string.Empty);
 
             var path = GetFullPath(tbDefinitionPath.Text);
             if (string.IsNullOrEmpty(path))
@@ -282,6 +285,18 @@ namespace DrawingLink.UI
         private void WpfOkCreateCancel_CancelClicked(object sender, EventArgs e)
         {
             Close();
+        }
+
+        internal void DisplayServerInfo(string scriptFullPath)
+        {
+            if (string.IsNullOrEmpty(scriptFullPath))
+            {
+                serverModeInfo.Content = string.Empty;
+                return;
+            }
+
+            var fileName = Path.GetFileName(scriptFullPath);
+            serverModeInfo.Content = $"Completed in the background: {fileName}";
         }
     }
 }

--- a/src/DrawingLink.UI/MainWindow.xaml.cs
+++ b/src/DrawingLink.UI/MainWindow.xaml.cs
@@ -65,10 +65,15 @@ namespace DrawingLink.UI
             MessageBox.Show(this, "Restart Grasshopper Application to load new Rhino version");
         }
 
-        private void ApplicationWindowBase_Loaded(object sender, RoutedEventArgs e)
+        public void InitalizeRhino()
         {
             _instance = GrasshopperCaller.GetInstance();
             _loaded = true;
+        }
+
+        private void ApplicationWindowBase_Loaded(object sender, RoutedEventArgs e)
+        {
+            InitalizeRhino();
 
             this.tbLaunchingRhino.Text = "Waiting for definition file ...";
         }

--- a/src/DrawingLink.UI/MainWindow.xaml.cs
+++ b/src/DrawingLink.UI/MainWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace DrawingLink.UI
             property.SetValue(_viewModel, args.Value);
         }
 
-        private void WpfOkCreateCancel_CreateClicked(object sender, EventArgs e)
+        public void ExecuteScript()
         {
             var path = GetFullPath(_viewModel.DefinitionPath);
             if (string.IsNullOrEmpty(path))
@@ -151,6 +151,11 @@ namespace DrawingLink.UI
 
             if (teklaParams.ModelParams.Count > 0)
                 new Tekla.Structures.Model.Model().CommitChanges();
+        }
+
+        private void WpfOkCreateCancel_CreateClicked(object sender, EventArgs e)
+        {
+            ExecuteScript();
         }
 
         private string GetTitle(string definitionPath)

--- a/src/DrawingLink.UI/Properties/launchSettings.json
+++ b/src/DrawingLink.UI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DrawingLink.UI": {
       "commandName": "Project",
-      "commandLineArgs": "-f \"Test with space.DrawingLink.UI.MainWindow.xml\""
+      "commandLineArgs": "-f \"Template 5.DrawingLink.UI.MainWindow.xml\""
     }
   }
 }

--- a/src/DrawingLink.UI/Properties/launchSettings.json
+++ b/src/DrawingLink.UI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DrawingLink.UI": {
       "commandName": "Project",
-      "commandLineArgs": "-f Test.DrawingLink.UI.MainWindow.xml"
+      "commandLineArgs": "-f \"Test with space.DrawingLink.UI.MainWindow.xml\""
     }
   }
 }

--- a/src/DrawingLink.UI/Properties/launchSettings.json
+++ b/src/DrawingLink.UI/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "DrawingLink.UI": {
+      "commandName": "Project",
+      "commandLineArgs": "-f Test.DrawingLink.UI.MainWindow.xml"
+    }
+  }
+}

--- a/src/DrawingLink.UI/Properties/launchSettings.json
+++ b/src/DrawingLink.UI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DrawingLink.UI": {
       "commandName": "Project",
-      "commandLineArgs": "-f \"Template 5.DrawingLink.UI.MainWindow.xml\""
+      "commandLineArgs": "-f \"Adjust bottom level -2000.DrawingLink.UI.MainWindow.xml\""
     }
   }
 }

--- a/src/DrawingLink.UI/StartupOptions.cs
+++ b/src/DrawingLink.UI/StartupOptions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Tekla.Structures.Dialog.UIControls;
+
+namespace DrawingLink.UI;
+internal class StartupOptions
+{
+    public string? SettingsFilePath { get; }
+
+    private StartupOptions(string settingsFilePath)
+    {
+        SettingsFilePath = settingsFilePath;
+    }
+
+    public static StartupOptions ParseArguments(string[] startupEventArgs)
+    {
+        try
+        {
+            if (startupEventArgs.Length == 2 &&
+                startupEventArgs[0] == "-f")
+            {
+                var filePath = startupEventArgs[1];
+
+                if (System.IO.File.Exists(filePath))
+                    return new StartupOptions(filePath);
+                else
+                {
+                    var teklaFilePath = EnvironmentFiles.GetAttributeFile(filePath);
+                    if (teklaFilePath != null)
+                        return new StartupOptions(teklaFilePath.FullName);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Should log failure details
+        }
+
+        return new StartupOptions(string.Empty);
+    }
+}

--- a/src/DrawingLink.UI/StartupUtils/AppOperationMode.cs
+++ b/src/DrawingLink.UI/StartupUtils/AppOperationMode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace DrawingLink.UI.StartupUtils;
+
+
+[Flags]
+public enum AppOperationMode
+{
+    UI = 1 << 0,
+    Background = 1 << 1,
+    Server = 1 << 2,
+    Client = 1 << 3,
+}

--- a/src/DrawingLink.UI/StartupUtils/MutexController.cs
+++ b/src/DrawingLink.UI/StartupUtils/MutexController.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+
+namespace DrawingLink.UI.StartupUtils;
+
+/// <summary>
+/// Only the UI server mode should have single instance
+/// The idea behind this class is to tell if some other server is already running
+/// </summary>
+internal class MutexController
+{
+    private static Mutex? _mutex;
+
+    public static bool ShouldRunAsServer(string teklaVersion)
+    {
+        var name = EstablishMutexName(teklaVersion);
+
+        var mutex = new Mutex(true, name, out bool isFirstInstance);
+        if (isFirstInstance)
+        {
+            _mutex = mutex;
+            return true;
+        }
+        else
+        {
+            mutex.Dispose();
+
+            return false;
+        }        
+    }
+
+    private static string EstablishMutexName(string teklaVersion)
+    {
+        return $"GrasshopperApplication{teklaVersion}_SingleInstance";
+    }
+}

--- a/src/DrawingLink.UI/StartupUtils/NamedPipeController.cs
+++ b/src/DrawingLink.UI/StartupUtils/NamedPipeController.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.RegularExpressions;
+
+namespace DrawingLink.UI.StartupUtils;
+internal class NamedPipeController
+{
+    private readonly string _name;
+
+    public NamedPipeController(string teklaVersion)
+    {
+        _name = GetPipeName(teklaVersion);
+    }
+
+    public static string GetPipeName(string teklaVersion)
+        => Regex.Replace($"GrasshopperApplication{teklaVersion}_Pipe", @"\s+", ".");    
+
+    public bool DoesPipeExist()
+    {
+        return System.IO.File.Exists($@"\\.\pipe\{_name}");
+    }
+}

--- a/src/DrawingLink.UI/StartupUtils/StartupController.cs
+++ b/src/DrawingLink.UI/StartupUtils/StartupController.cs
@@ -1,0 +1,35 @@
+﻿using System.Windows;
+
+namespace DrawingLink.UI.StartupUtils;
+internal class StartupController
+{
+    private readonly StartupOptions _startupOptions;
+    private readonly string _teklaVersion;
+    private NamedPipeController? _namedPipeController;
+
+    public StartupController(StartupEventArgs e, string teklaVersion)
+    {
+        _startupOptions = StartupOptions.ParseArguments(e.Args);
+        _teklaVersion = teklaVersion;
+    }
+
+    public AppOperationMode EstablishOperationMode()
+    {
+        if (string.IsNullOrWhiteSpace(_startupOptions.SettingsFilePath)) // UI Mode
+        {
+            if (MutexController.ShouldRunAsServer(_teklaVersion))
+                return AppOperationMode.UI | AppOperationMode.Server;
+            else
+                return AppOperationMode.UI;
+        }
+        else // Background Mode
+        {
+            // Check if there is an active server
+            _namedPipeController = new NamedPipeController(_teklaVersion);
+            if (_namedPipeController.DoesPipeExist())
+                return AppOperationMode.Background | AppOperationMode.Client;
+            else
+                return AppOperationMode.Background;
+        }
+    }
+}

--- a/src/DrawingLink.UI/StartupUtils/StartupOptions.cs
+++ b/src/DrawingLink.UI/StartupUtils/StartupOptions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Tekla.Structures.Dialog.UIControls;
 
-namespace DrawingLink.UI;
+namespace DrawingLink.UI.StartupUtils;
 internal class StartupOptions
 {
     public string? SettingsFilePath { get; }
@@ -37,4 +37,12 @@ internal class StartupOptions
 
         return new StartupOptions(string.Empty);
     }
+}
+
+internal class StartupOptionsDto
+{
+    public string SettingsFilePath { get; set; }
+
+    public static StartupOptionsDto FromDomain(StartupOptions startupOptions)
+        => new StartupOptionsDto() { SettingsFilePath = startupOptions.SettingsFilePath };
 }


### PR DESCRIPTION
# Script Like a Macro

*Script like a macro* is a feature of the **Grasshopper Application** that lets you quickly run your Grasshopper scripts without manually reloading settings in the Grasshopper Application window.

## How It Works

This feature relies on an already-opened instance of the Grasshopper Application. Open it once, minimize it or move it to an unused corner of your screen, then trigger the macro. The macro will instruct the open instance to do its job.

## Configuration

A sample macro is provided in the `Grasshopper - Macro sample.cs` file. You'll need to adapt its content to your needs (it's a plain text file, so Notepad is sufficient). Look for this line:

​```
NewProcess.StartInfo.Arguments = "-f \"SETTINGS.DrawingLink.UI.MainWindow.xml\"";
​```

This is the anchor point between your macro and the Grasshopper Application. Change it to reference the pre-saved settings of the Grasshopper Application (visible as a combobox at the top of the UI), which control both the script path and the input values.